### PR TITLE
Use non-streaming mode and default compression level 6

### DIFF
--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -41,10 +41,13 @@ class SecureTarFile:
         self._mode: str = mode
         self._name: Path = name
         self._bufsize: int = bufsize
+        self._extra_args = {}
 
         # Tarfile options
         self._tar: Optional[tarfile.TarFile] = None
-        self._tar_mode: str = f"{mode}|gz" if gzip else f"{mode}|"
+        self._tar_mode: str = f"{mode}:gz" if gzip else f"{mode}|"
+        if gzip:
+            self._extra_args["compresslevel"] = 6
 
         # Encryption/Description
         self._aes: Optional[Cipher] = None
@@ -62,6 +65,7 @@ class SecureTarFile:
                 mode=self._tar_mode,
                 dereference=False,
                 bufsize=self._bufsize,
+                **self._extra_args
             )
             return self._tar
 


### PR DESCRIPTION
The streaming mode (using | before the compression) seems to be quite a bit slower. This restricts the input to a file, but which is typically the case.

The compression level of 6 is the default and significantly increases performance with similar compression ratio.

In a test using Home Assistant Supervisor's Backup functionality backup time decreased from 4min 21s to 3min 33s without streaming mode, and further down to 2min 32s with compression level set to 6. The compression level 6 increased only by 1MB (at 632.8MB to 633.8MB), altough about 90% of data were not compressable data (JPEG). But also other comparision benchmark only report marginal difference in compression ratio.