### PR TITLE
Add support for creating inner tar files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,32 @@ with SecureTarFile("test.tar", "w", b"AES128_KEY_SIZE") as tar_file:
 
 ```
 
+A common pattern is to create an outer uncompressed tarfile that contains
+a variety of inner tar files. This can be accomplished without writing 
+out multiple files with the following pattern.
+
+```python
+
+outer_secure_tar_file = SecureTarFile("pkg.tar", "w", gzip=False)
+with outer_secure_tar_file as outer_tar_file:
+    with outer_secure_tar_file.create_inner_tar(
+        "./backup1.tar.gz", gzip=True
+    ) as inner_tar_file:
+        atomic_contents_add(
+            inner_tar_file,
+            path_1,
+            excludes=[],
+            arcname=".",
+        )
+
+    with outer_secure_tar_file.create_inner_tar(
+        "./backup2.tar.gz", gzip=True
+    ) as inner_tar_file:
+        atomic_contents_add(
+            inner_tar_file,
+            path_2,
+            excludes=[],
+            arcname=".",
+        )
+
+```

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -6,7 +6,7 @@ import tarfile
 import time
 from contextlib import contextmanager
 from pathlib import Path, PurePath
-from typing import IO, Generator, Optional
+from typing import BinaryIO, IO, Generator, Optional
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import padding
@@ -192,7 +192,7 @@ class InnerSecureTarFile(SecureTarFile):
             fileobj=fileobj,
         )
         self.outer_tar = outer_tar
-        self.stream: Generator[tarfile.ExFileObject, None, None] | None = None
+        self.stream: Generator[BinaryIO, None, None] | None = None
 
     def __enter__(self) -> tarfile.TarFile:
         """Start context manager tarfile."""
@@ -211,7 +211,7 @@ class InnerSecureTarFile(SecureTarFile):
 @contextmanager
 def add_stream(
     tar: tarfile.TarFile, tar_info: tarfile.TarInfo
-) -> Generator[tarfile.ExFileObject, None, None]:
+) -> Generator[BinaryIO, None, None]:
     """Add a stream to the tarfile.
 
     This only works with uncompressed, unencrypted tar files.

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -5,7 +5,7 @@ import os
 import tarfile
 import time
 from pathlib import Path, PurePath
-from typing import IO, Any, Generator, Optional
+from typing import IO, Generator, Optional
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import padding

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -5,7 +5,7 @@ import os
 import tarfile
 from contextlib import contextmanager
 from pathlib import Path, PurePath
-from typing import IO, Generator, Optional
+from typing import Any, IO, Generator, Optional
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import padding
@@ -71,7 +71,7 @@ class SecureTarFile:
     @contextmanager
     def create_inner_tar(
         self, name: str, key: Optional[bytes] = None, gzip: bool = True
-    ) -> Generator[tarfile.TarFile]:
+    ) -> Generator[tarfile.TarFile, Any, Any]:
         """Create inner tar file."""
         outer_tar = self._tar
         assert outer_tar

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -219,9 +219,8 @@ class InnerSecureTarFile(SecureTarFile):
         outer_tar = self.outer_tar
         fileobj = outer_tar.fileobj
 
-        tell_after_adding_inner_file = fileobj.tell()
         size_of_inner_tar = (
-            tell_after_adding_inner_file
+            fileobj.tell()
             - self.tell_before_adding_inner_file_header
             - self.tar_info_header_len
         )

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -71,7 +71,7 @@ class SecureTarFile:
     @contextmanager
     def create_inner_tar(
         self, name: str, key: Optional[bytes] = None, gzip: bool = True
-    ) -> Generator[Any, Any, tarfile.TarFile]:
+    ) -> Generator[tarfile.TarFile]:
         """Create inner tar file."""
         outer_tar = self._tar
         assert outer_tar

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -211,7 +211,7 @@ class InnerSecureTarFile(SecureTarFile):
 @contextmanager
 def add_stream(
     tar: tarfile.TarFile, tar_info: tarfile.TarInfo
-) -> Generator[None, None, None]:
+) -> Generator[tarfile.ExFileObject, None, None]:
     """Add a stream to the tarfile.
 
     This only works with uncompressed, unencrypted tar files.

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -196,7 +196,7 @@ class _InnerSecureTarFile(SecureTarFile):
         """Start context manager tarfile."""
         tar_info = tarfile.TarInfo(name=str(self._name))
         tar_info.mtime = time.time()
-        self.stream = add_stream(self.outer_tar, tar_info)
+        self.stream = _add_stream(self.outer_tar, tar_info)
         self.stream.__enter__()
         return super().__enter__()
 
@@ -207,7 +207,7 @@ class _InnerSecureTarFile(SecureTarFile):
 
 
 @contextmanager
-def add_stream(
+def _add_stream(
     tar: tarfile.TarFile, tar_info: tarfile.TarInfo
 ) -> Generator[BinaryIO, None, None]:
     """Add a stream to the tarfile.
@@ -216,8 +216,12 @@ def add_stream(
 
     The typical usage is:
 
-    with add_stream(tar, tar_info) as fileobj:
+    with _add_stream(tar, tar_info) as fileobj:
         fileobj.write(data)
+
+    It is critical that the tar_info is not modified
+    inside the context manager, as the tar file header
+    size may change.
     """
     fileobj = tar.fileobj
     tell_before_adding_inner_file_header = fileobj.tell()

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -196,10 +196,6 @@ class InnerSecureTarFile(SecureTarFile):
 
     def __enter__(self) -> tarfile.TarFile:
         """Start context manager tarfile."""
-        fileobj = self.outer_tar.fileobj
-        self.tell_before_adding_inner_file_header = fileobj.tell()
-        # Write an empty header for the inner tar file
-        # We'll seek back to this position later to update the header with the correct size
         tar_info = tarfile.TarInfo(name=str(self._name))
         tar_info.mtime = time.time()
         self.stream = add_stream(self.outer_tar, tar_info)

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -228,8 +228,6 @@ def add_stream(
     fileobj.write(tar_info_header)
     try:
         yield fileobj
-    except Exception:  # pylint: disable=broad-except
-        raise
     finally:
         tell_after_writing_inner_tar = fileobj.tell()
         size_of_inner_tar = (

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -170,6 +170,8 @@ class SecureTarFile:
 
 
 class InnerSecureTarFile(SecureTarFile):
+    """Handle encrypted files for tarfile library inside another tarfile."""
+
     def __init__(
         self,
         name: Path,

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -195,7 +195,7 @@ class _InnerSecureTarFile(SecureTarFile):
     def __enter__(self) -> tarfile.TarFile:
         """Start context manager tarfile."""
         tar_info = tarfile.TarInfo(name=str(self._name))
-        tar_info.mtime = time.time()
+        tar_info.mtime = int(time.time())
         self.stream = _add_stream(self.outer_tar, tar_info)
         self.stream.__enter__()
         return super().__enter__()

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -104,7 +104,7 @@ class SecureTarFile:
             if read_mode:
                 file_mode: int = os.O_RDONLY
             else:
-                file_mode: int = os.O_WRONLY | os.O_CREAT
+                file_mode = os.O_WRONLY | os.O_CREAT
 
             fd = os.open(self._name, file_mode, 0o666)
             self._file = os.fdopen(fd, "rb" if read_mode else "wb")

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -5,7 +5,7 @@ import os
 import tarfile
 from contextlib import contextmanager
 from pathlib import Path, PurePath
-from typing import IO, Any, Generator, Optional
+from typing import IO, Generator, Optional
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import padding

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -182,6 +182,7 @@ class InnerSecureTarFile(SecureTarFile):
         fileobj: Optional[IO[bytes]] = None,
         outer_tar: Optional[tarfile.TarFile] = None,
     ) -> None:
+        """Initialize inner handler."""
         super().__init__(
             name=name,
             mode=mode,

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -72,13 +72,12 @@ class SecureTarFile:
     ) -> "InnerSecureTarFile":
         """Create inner tar file."""
         return InnerSecureTarFile(
+            self._tar,
             name=Path(name),
             mode=self._mode,
             key=key,
             gzip=gzip,
             bufsize=self._bufsize,
-            fileobj=self._tar.fileobj,
-            outer_tar=self._tar,
         )
 
     def __enter__(self) -> tarfile.TarFile:
@@ -174,13 +173,12 @@ class InnerSecureTarFile(SecureTarFile):
 
     def __init__(
         self,
+        outer_tar: tarfile.TarFile,
         name: Path,
         mode: str,
         key: Optional[bytes] = None,
         gzip: bool = True,
         bufsize: int = DEFAULT_BUFSIZE,
-        fileobj: Optional[IO[bytes]] = None,
-        outer_tar: Optional[tarfile.TarFile] = None,
     ) -> None:
         """Initialize inner handler."""
         super().__init__(
@@ -189,7 +187,7 @@ class InnerSecureTarFile(SecureTarFile):
             key=key,
             gzip=gzip,
             bufsize=bufsize,
-            fileobj=fileobj,
+            fileobj=outer_tar.fileobj,
         )
         self.outer_tar = outer_tar
         self.stream: Generator[BinaryIO, None, None] | None = None

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -6,7 +6,7 @@ import tarfile
 import time
 from contextlib import contextmanager
 from pathlib import Path, PurePath
-from typing import BinaryIO, IO, Generator, Optional
+from typing import IO, BinaryIO, Generator, Optional
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import padding

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -3,6 +3,7 @@ import hashlib
 import logging
 import os
 import tarfile
+import time
 from pathlib import Path, PurePath
 from typing import IO, Any, Generator, Optional
 
@@ -221,6 +222,7 @@ class InnerSecureTarFile(SecureTarFile):
 
         tar_info = tarfile.TarInfo(name=str(self._name))
         tar_info.size = size_of_inner_tar
+        tar_info.mtime = time.time()
         # Now that we know the size of the inner tar, we seek back
         # to where we started and re-add the member with the correct size
         fileobj.seek(self.offset_before_adding_inner_file_header)

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -192,7 +192,7 @@ class InnerSecureTarFile(SecureTarFile):
             fileobj=fileobj,
         )
         self.outer_tar = outer_tar
-        self.stream: Generator[None, None, None] | None = None
+        self.stream: Generator[tarfile.ExFileObject, None, None] | None = None
 
     def __enter__(self) -> tarfile.TarFile:
         """Start context manager tarfile."""

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -198,11 +198,10 @@ class InnerSecureTarFile(SecureTarFile):
     def __enter__(self) -> tarfile.TarFile:
         """Start context manager tarfile."""
         outer_tar = self.outer_tar
-        fileobj = outer_tar.fileobj
         self.offset_before_adding_inner_file_header = outer_tar.offset
         # Write an empty header for the inner tar file
         # We'll seek back to this position later to update the header with the correct size
-        fileobj.write(EMPTY_TAR_INFO_BLOCK)
+        outer_tar.fileobj.write(EMPTY_TAR_INFO_BLOCK)
         self.inner_tar = super().__enter__()
         return self.inner_tar
 

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -69,9 +69,9 @@ class SecureTarFile:
 
     def create_inner_tar(
         self, name: str, key: Optional[bytes] = None, gzip: bool = True
-    ) -> "InnerSecureTarFile":
+    ) -> "_InnerSecureTarFile":
         """Create inner tar file."""
-        return InnerSecureTarFile(
+        return _InnerSecureTarFile(
             self._tar,
             name=Path(name),
             mode=self._mode,
@@ -168,7 +168,7 @@ class SecureTarFile:
         return round(self._name.stat().st_size / 1_048_576, 2)  # calc mbyte
 
 
-class InnerSecureTarFile(SecureTarFile):
+class _InnerSecureTarFile(SecureTarFile):
     """Handle encrypted files for tarfile library inside another tarfile."""
 
     def __init__(

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -13,7 +13,7 @@ import pytest
 from securetar import (
     SecureTarFile,
     _is_excluded_by_filter,
-    add_stream,
+    _add_stream,
     atomic_contents_add,
     secure_path,
 )
@@ -387,7 +387,7 @@ def test_tar_stream(tmp_path: Path) -> None:
 
     with SecureTarFile(main_tar, "w", gzip=False) as tar_file:
         tar_info = tarfile.TarInfo(name="test.txt")
-        with add_stream(tar_file, tar_info) as stream:
+        with _add_stream(tar_file, tar_info) as stream:
             stream.write(b"test")
 
     # Restore

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -10,8 +10,13 @@ from pathlib import Path, PurePath
 
 import pytest
 
-from securetar import (SecureTarFile, _is_excluded_by_filter, add_stream,
-                       atomic_contents_add, secure_path)
+from securetar import (
+    SecureTarFile,
+    _is_excluded_by_filter,
+    add_stream,
+    atomic_contents_add,
+    secure_path,
+)
 
 
 @dataclass

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -181,6 +181,7 @@ def test_gzipped_tar_inside_tar(tmp_path: Path) -> None:
         tar_info.size = len(raw_bytes)
         tar_info.mtime = time.time()
         outer_tar_file.addfile(tar_info, fileobj=fileobj)
+        assert len(outer_tar_file.getmembers()) == 4
 
     assert main_tar.exists()
     # Restore

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -10,13 +10,8 @@ from pathlib import Path, PurePath
 
 import pytest
 
-from securetar import (
-    SecureTarFile,
-    _is_excluded_by_filter,
-    add_stream,
-    atomic_contents_add,
-    secure_path,
-)
+from securetar import (SecureTarFile, _is_excluded_by_filter, add_stream,
+                       atomic_contents_add, secure_path)
 
 
 @dataclass

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -362,3 +362,14 @@ def test_inner_tar_not_allowed_in_encrypted(tmp_path: Path) -> None:
         with outer_secure_tar_file:
             with outer_secure_tar_file.create_inner_tar("any.tgz", gzip=True):
                 pass
+
+
+def test_outer_tar_must_not_be_compressed(tmp_path: Path) -> None:
+    # Create Tarfile
+    main_tar = tmp_path.joinpath("backup.tar.gz")
+    outer_secure_tar_file = SecureTarFile(main_tar, "w", gzip=True)
+
+    with pytest.raises(OSError):
+        with outer_secure_tar_file:
+            with outer_secure_tar_file.create_inner_tar("any.tgz", gzip=True):
+                pass

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -1,4 +1,5 @@
 """Test Tarfile functions."""
+import gzip
 import io
 import os
 import shutil
@@ -190,7 +191,12 @@ def test_gzipped_tar_inside_tar(tmp_path: Path) -> None:
         tar_file.extractall(path=temp_new)
 
     assert temp_new.is_dir()
-    assert temp_new.joinpath("core.tar.gz").is_file()
+    core_tar_gz = temp_new.joinpath("core.tar.gz")
+    assert core_tar_gz.is_file()
+    compressed = core_tar_gz.read_bytes()
+    uncompressed = gzip.decompress(core_tar_gz.read_bytes())
+    assert len(uncompressed) > len(compressed)
+
     assert temp_new.joinpath("core2.tar.gz").is_file()
     assert temp_new.joinpath("core3.tar.gz").is_file()
     backup_json = temp_new.joinpath("backup.json")

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -10,13 +10,8 @@ from pathlib import Path, PurePath
 
 import pytest
 
-from securetar import (
-    SecureTarFile,
-    add_stream,
-    _is_excluded_by_filter,
-    atomic_contents_add,
-    secure_path,
-)
+from securetar import (SecureTarFile, _is_excluded_by_filter, add_stream,
+                       atomic_contents_add, secure_path)
 
 
 @dataclass
@@ -374,7 +369,6 @@ def test_outer_tar_must_not_be_compressed(tmp_path: Path) -> None:
         with outer_secure_tar_file:
             with outer_secure_tar_file.create_inner_tar("any.tgz", gzip=True):
                 pass
-
 
 
 def test_tar_stream(tmp_path: Path) -> None:

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -1,6 +1,7 @@
 """Test Tarfile functions."""
 import os
 import shutil
+import tarfile
 from dataclasses import dataclass
 from pathlib import Path, PurePath
 
@@ -260,3 +261,16 @@ def test_encrypted_gzipped_tar_inside_tar(tmp_path: Path) -> None:
             "775",
         ]
         assert temp_inner_new.joinpath("README.md").is_file()
+
+
+def test_inner_tar_not_allowed_in_encrypted(tmp_path: Path) -> None:
+    # Create Tarfile
+    main_tar = tmp_path.joinpath("backup.tar")
+    key = os.urandom(16)
+
+    outer_secure_tar_file = SecureTarFile(main_tar, "w", key=key, gzip=False)
+
+    with pytest.raises(tarfile.StreamError):
+        with outer_secure_tar_file:
+            with outer_secure_tar_file.create_inner_tar("any.tgz", gzip=True):
+                pass


### PR DESCRIPTION
supports https://github.com/home-assistant/supervisor/pull/4884 and https://github.com/home-assistant/core/pull/110267

This allows us to avoid creating all the inner tar files as seperate files on disk and than having to copy them back into the main archive. This will allow us to effectively cut the disk writes in half when creating backups and increase storage media longevity. Additionally this means the user no longer needs twice as much disk space as the backup size since there is only one copy of the backup being written to disk now.

In home-assistant/supervisor#4843 I noticed a large chunk of the time on I/O bound systems is copying the data into the tarfile and than making another tarfile of the original tarfiles.

To avoid the double copy, we now write each tarfile into the fileobj of the outer tar file.

This reduced my backup time on my fast system from 24s to 10s.  On I/O bound systems the reduction is multiple minutes.

All new lines are covered

```
---------- coverage: platform darwin, python 3.12.1-final-0 ----------
Name                    Stmts   Miss  Cover   Missing
-----------------------------------------------------
securetar/__init__.py     157      6    96%   162, 167-169, 307, 314
-----------------------------------------------------
TOTAL                     157      6    96%
```

Example usage:

```python
    outer_secure_tar_file = SecureTarFile(main_tar, "w", gzip=False)
    with outer_secure_tar_file as outer_tar_file:
        for inner_tgz_file in inner_tgz_files:
            with outer_secure_tar_file.create_inner_tar(
                inner_tgz_file, gzip=True
            ) as inner_tar_file:
                atomic_contents_add(
                    inner_tar_file,
                    temp_orig,
                    excludes=[],
                    arcname=".",
                )
```