### PR TITLE
Fix large inner files with PAX format

### DIFF
--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -201,7 +201,7 @@ class _InnerSecureTarFile(SecureTarFile):
             # a PAX header to be written.
             #
             # This is necessary to
-            # handle large files as TarInfo.to_buf will try to
+            # handle large files as TarInfo.tobuf will try to
             # use a shorter ustar header if we do not have at
             # least one float in the tarinfo.
             # https://github.com/python/cpython/blob/53b84e772cac6e4a55cebf908d6bb9c48fe254dc/Lib/tarfile.py#L1066

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -204,7 +204,7 @@ class _InnerSecureTarFile(SecureTarFile):
             # handle large files as TarInfo.to_buf will try to
             # use a shorter ustar header if we do not have at
             # least one float in the tarinfo.
-            # https://github.com/python/cpython/blob/53b84e772cac6e4a55cebf908d6bb9c48fe254dc/Lib/tarfile.py#L1062
+            # https://github.com/python/cpython/blob/53b84e772cac6e4a55cebf908d6bb9c48fe254dc/Lib/tarfile.py#L1066
             tar_info.mtime = time.time()
         else:
             tar_info.mtime = int(time.time())

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -196,7 +196,18 @@ class _InnerSecureTarFile(SecureTarFile):
     def __enter__(self) -> tarfile.TarFile:
         """Start context manager tarfile."""
         tar_info = tarfile.TarInfo(name=str(self._name))
-        tar_info.mtime = int(time.time())
+        if self.outer_tar.format == tarfile.PAX_FORMAT:
+            # Ensure we always set mtime as a float to force
+            # a PAX header to be written.
+            #
+            # This is necessary to
+            # handle large files as TarInfo.to_buf will try to
+            # use a shorter ustar header if we do not have at
+            # least one float in the tarinfo.
+            # https://github.com/python/cpython/blob/53b84e772cac6e4a55cebf908d6bb9c48fe254dc/Lib/tarfile.py#L1062
+            tar_info.mtime = time.time()
+        else:
+            tar_info.mtime = int(time.time())
         self.stream = _add_stream(self.outer_tar, tar_info)
         self.stream.__enter__()
         return super().__enter__()

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -376,7 +376,10 @@ def test_outer_tar_must_not_be_compressed(tmp_path: Path) -> None:
             with outer_secure_tar_file.create_inner_tar("any.tgz", gzip=True):
                 pass
 
-@pytest.mark.parametrize("format", [tarfile.PAX_FORMAT, tarfile.GNU_FORMAT, tarfile.USTAR_FORMAT])
+
+@pytest.mark.parametrize(
+    "format", [tarfile.PAX_FORMAT, tarfile.GNU_FORMAT, tarfile.USTAR_FORMAT]
+)
 def test_tar_stream(tmp_path: Path, format: int) -> None:
     # Prepare test folder
     temp_orig = tmp_path.joinpath("orig")
@@ -386,8 +389,7 @@ def test_tar_stream(tmp_path: Path, format: int) -> None:
     # Create Tarfile
     main_tar = tmp_path.joinpath("backup.tar")
 
-    with patch.object(tarfile,"DEFAULT_FORMAT", format):
-
+    with patch.object(tarfile, "DEFAULT_FORMAT", format):
         with SecureTarFile(main_tar, "w", gzip=False) as tar_file:
             tar_info = tarfile.TarInfo(name="test.txt")
             with _add_stream(tar_file, tar_info) as stream:

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -8,7 +8,7 @@ import tarfile
 import time
 from dataclasses import dataclass
 from pathlib import Path, PurePath
-
+from unittest.mock import patch
 import pytest
 
 from securetar import (
@@ -376,8 +376,8 @@ def test_outer_tar_must_not_be_compressed(tmp_path: Path) -> None:
             with outer_secure_tar_file.create_inner_tar("any.tgz", gzip=True):
                 pass
 
-
-def test_tar_stream(tmp_path: Path) -> None:
+@pytest.mark.parametrize("format", [tarfile.PAX_FORMAT, tarfile.GNU_FORMAT, tarfile.USTAR_FORMAT])
+def test_tar_stream(tmp_path: Path, format: int) -> None:
     # Prepare test folder
     temp_orig = tmp_path.joinpath("orig")
     fixture_data = Path(__file__).parent.joinpath("fixtures/tar_data")
@@ -386,17 +386,19 @@ def test_tar_stream(tmp_path: Path) -> None:
     # Create Tarfile
     main_tar = tmp_path.joinpath("backup.tar")
 
-    with SecureTarFile(main_tar, "w", gzip=False) as tar_file:
-        tar_info = tarfile.TarInfo(name="test.txt")
-        with _add_stream(tar_file, tar_info) as stream:
-            stream.write(b"test")
+    with patch.object(tarfile,"DEFAULT_FORMAT", format):
 
-    # Restore
-    temp_new = tmp_path.joinpath("new")
-    with SecureTarFile(main_tar, "r", gzip=False) as tar_file:
-        tar_file.extractall(path=temp_new)
+        with SecureTarFile(main_tar, "w", gzip=False) as tar_file:
+            tar_info = tarfile.TarInfo(name="test.txt")
+            with _add_stream(tar_file, tar_info) as stream:
+                stream.write(b"test")
 
-    assert temp_new.is_dir()
-    test_file = temp_new.joinpath("test.txt")
-    assert test_file.is_file()
-    assert test_file.read_bytes() == b"test"
+        # Restore
+        temp_new = tmp_path.joinpath("new")
+        with SecureTarFile(main_tar, "r", gzip=False) as tar_file:
+            tar_file.extractall(path=temp_new)
+
+        assert temp_new.is_dir()
+        test_file = temp_new.joinpath("test.txt")
+        assert test_file.is_file()
+        assert test_file.read_bytes() == b"test"


### PR DESCRIPTION
If the file size is larger than 12 digits tarfile writes a larger header when using PAX. Since we can't set the size to anything other than 0 initially (in case the inner tar creation raise), we set the mtime to a float to ensure we get a PAX header

fixes https://github.com/home-assistant/supervisor/issues/4924