### PR TITLE
Bump minimum support Python version to 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.9.0"
+requires-python = ">=3.10.0"
 dynamic = ["dependencies"]
 
 [project.urls]


### PR DESCRIPTION
Bump minimum support Python version to 3.10

Rationale:
Python version 3.10 introduced modern type annotations