### PR TITLE
Bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "securetar"
-version     = "2024.11.1"
+version     = "2024.11.0"
 license     = {text = "Apache-2.0"}
 description = "Python module to handle tarfile backups."
 readme      = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "securetar"
-version     = "2024.2.1"
+version     = "2024.11.1"
 license     = {text = "Apache-2.0"}
 description = "Python module to handle tarfile backups."
 readme      = "README.md"


### PR DESCRIPTION
2024.11.0 was not released as the version was not bumped, thus it was trying to publish 2024.2.1 again. Instead of trying 2024.11.0 again, let's make 2024.11.1