### PR TITLE
Store size of plaintext as custom header

### DIFF
--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -295,6 +295,11 @@ def _add_stream(
     It is critical that the tar_info is not modified
     inside the context manager, as the tar file header
     size may change.
+
+    :param padding: PKCS7 padding added at the end of the inner tar. If non-empty,
+    the inner tar is encrypted, and we calculate the plaintext size from the padding
+    and add a pax header with the plaintext size. If empty, the inner tar is not
+    encrypted and we don't add a plaintext size pax header.
     """
     fileobj = tar.fileobj
     tell_before_adding_inner_file_header = fileobj.tell()

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -296,7 +296,9 @@ def _add_stream(
     inside the context manager, as the tar file header
     size may change.
 
-    :param padding: PKCS7 padding added at the end of the inner tar. If non-empty,
+    :param tar: The outer tar file to add the stream to.
+    :param tar_info: TarInfo for the added stream.
+    :param padding: PKCS7 padding added at the end of the stream. If non-empty,
     the inner tar is encrypted, and we calculate the plaintext size from the padding
     and add a pax header with the plaintext size. If empty, the inner tar is not
     encrypted and we don't add a plaintext size pax header.

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -348,7 +348,9 @@ def test_encrypted_gzipped_tar_inside_tar(tmp_path: Path, bufsize: int) -> None:
     file_sizes: dict[str, int] = {}
     with SecureTarFile(main_tar, "r", gzip=False, bufsize=bufsize) as tar_file:
         for tar_info in tar_file:
-            file_sizes[tar_info.name] = tar_info.pax_headers["_securetar.plaintext_size"]
+            file_sizes[tar_info.name] = tar_info.pax_headers[
+                "_securetar.plaintext_size"
+            ]
     assert set(file_sizes) == {
         "core.tar.gz",
         "core2.tar.gz",


### PR DESCRIPTION
Store size of plaintext size of encrypted inner tar as custom PAX header.

This allows streaming a decrypted version of an encrypted archive.