### PR TITLE
Update typing of SecureTarFile construct to allow None name

### DIFF
--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -36,8 +36,8 @@ class SecureTarFile:
 
     def __init__(
         self,
-        name: Path | None,
-        mode: str,
+        name: Path | None = None,
+        mode: str = "r",
         key: bytes | None = None,
         gzip: bool = True,
         bufsize: int = DEFAULT_BUFSIZE,

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -36,7 +36,7 @@ class SecureTarFile:
 
     def __init__(
         self,
-        name: Path,
+        name: Path | None,
         mode: str,
         key: bytes | None = None,
         gzip: bool = True,
@@ -46,7 +46,7 @@ class SecureTarFile:
         """Initialize encryption handler."""
         self._file: IO[bytes] | None = None
         self._mode: str = mode
-        self._name: Path = name
+        self._name: Path | None = name
         self._bufsize: int = bufsize
         self._extra_args = {}
         self._fileobj = fileobj
@@ -115,6 +115,8 @@ class SecureTarFile:
             # If we have a fileobj, we don't need to open a file
             self._file = self._fileobj
         else:
+            if not self._name:
+                raise ValueError("No filename or fileobj provided")
             read_mode = self._mode.startswith("r")
             if read_mode:
                 file_mode: int = os.O_RDONLY


### PR DESCRIPTION
Update typing of SecureTarFile construct to allow None name

The `name` parameter is ignored when passing in a fileobj, so we should allow passing in a `None` name
This better aligns with interface with that of stdlib tarfile: https://docs.python.org/3/library/tarfile.html#tarfile.TarFile