### PR TITLE
Modify atomic_contents_add to accept a filter function

### DIFF
--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -385,7 +385,7 @@ def _is_excluded_by_filter(path: PurePath, exclude_list: list[str]) -> bool:
     """Filter to filter excludes."""
 
     for exclude in exclude_list:
-        if not path.match(exclude):
+        if not path.full_match(exclude):
             continue
         _LOGGER.debug("Ignoring %s because of %s", path, exclude)
         return True

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -389,8 +389,8 @@ def atomic_contents_add(
 ) -> None:
     """Append directories and/or files to the TarFile if file_filter returns False.
 
-    :param file_filter: A filter function, should return False if the item should
-    be excluded from the archived. The function should take a single argument, a
+    :param file_filter: A filter function, should return True if the item should
+    be excluded from the archive. The function should take a single argument, a
     pathlib.PurePath object representing the relative path of the item to be archived.
     """
 

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -387,7 +387,12 @@ def atomic_contents_add(
     file_filter: Callable[[PurePath], bool],
     arcname: str = ".",
 ) -> None:
-    """Append directories and/or files to the TarFile if file_filter returns False."""
+    """Append directories and/or files to the TarFile if file_filter returns False.
+
+    :param file_filter: A filter function, should return False if the item should
+    be excluded from the archived. The function should take a single argument, a
+    pathlib.PurePath object representing the relative path of the item to be archived.
+    """
 
     if file_filter(PurePath(arcname)):
         return None

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -48,32 +48,24 @@ def test_not_secure_path() -> None:
     assert [] == list(secure_path(test_list))
 
 
-def test_is_excluded_by_filter_good() -> None:
+def test_is_excluded_by_filter() -> None:
     """Test exclude filter."""
-    filter_list = ["not/match", "/dev/xy"]
+    filter_list = ["not/match", "/dev/xy", "tts/**", "**/.DS_Store"]
     test_list = [
-        PurePath("test.txt"),
-        PurePath("data/xy.blob"),
-        PurePath("bla/blu/ble"),
-        PurePath("data/../xy.blob"),
+        (PurePath("test.txt"), False),
+        (PurePath("data/xy.blob"), False),
+        (PurePath("bla/blu/ble"), False),
+        (PurePath("data/../xy.blob"), False),
+        (PurePath("tts"), False),
+        (PurePath("tts/blah"), True),
+        (PurePath("tts/blah/bleh"), True),
+        (PurePath("data/tts"), False),
+        (PurePath(".DS_Store"), True),
+        (PurePath("data/.DS_Store"), True),
     ]
 
-    for path_object in test_list:
-        assert _is_excluded_by_filter(path_object, filter_list) is False
-
-
-def test_is_exclude_by_filter_bad() -> None:
-    """Test exclude filter."""
-    filter_list = ["*.txt", "data/*", "bla/blu/ble"]
-    test_list = [
-        PurePath("test.txt"),
-        PurePath("data/xy.blob"),
-        PurePath("bla/blu/ble"),
-        PurePath("data/test_files/kk.txt"),
-    ]
-
-    for path_object in test_list:
-        assert _is_excluded_by_filter(path_object, filter_list) is True
+    for path_object, expect_filtered in test_list:
+        assert _is_excluded_by_filter(path_object, filter_list) == expect_filtered
 
 
 @pytest.mark.parametrize("bufsize", [10240, 4 * 2**20])

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -7,7 +7,7 @@ import shutil
 import tarfile
 import time
 from dataclasses import dataclass
-from pathlib import Path, PurePath
+from pathlib import Path
 from unittest.mock import Mock, patch
 import pytest
 
@@ -47,10 +47,8 @@ def test_not_secure_path() -> None:
     assert [] == list(secure_path(test_list))
 
 
-def _test_file_filter() -> None:
-    """Test exclude filter."""
 def test_file_filter(tmp_path: Path) -> None:
-    """Test to create a tar file without encryption."""
+    """Test exclude filter."""
     file_filter = Mock(return_value=False)
     # Prepare test folder
     temp_orig = tmp_path.joinpath("orig")

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -7,7 +7,7 @@ import shutil
 import tarfile
 import time
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePath
 from unittest.mock import Mock, patch
 import pytest
 
@@ -64,16 +64,16 @@ def test_file_filter(tmp_path: Path) -> None:
             file_filter=file_filter,
             arcname=".",
         )
-    paths = {call[1][0] for call in file_filter.mock_calls}
+    paths = [call[1][0] for call in file_filter.mock_calls]
     expected_paths = {
-        temp_orig,
-        temp_orig / "README.md",
-        temp_orig / "test_symlink",
-        temp_orig / "test1",
-        temp_orig / "test1",
-        temp_orig / "test1/script.sh",
+        PurePath("."),
+        PurePath("README.md"),
+        PurePath("test_symlink"),
+        PurePath("test1"),
+        PurePath("test1/script.sh"),
     }
-    assert paths == expected_paths
+    assert len(paths) == len(expected_paths)
+    assert set(paths) == expected_paths
 
 
 @pytest.mark.parametrize("bufsize", [10240, 4 * 2**20])

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -64,15 +64,15 @@ def test_file_filter(tmp_path: Path) -> None:
             file_filter=file_filter,
             arcname=".",
         )
-    paths = [call[1][0] for call in file_filter.mock_calls]
-    expected_paths = [
+    paths = {call[1][0] for call in file_filter.mock_calls}
+    expected_paths = {
         temp_orig,
         temp_orig / "README.md",
         temp_orig / "test_symlink",
         temp_orig / "test1",
         temp_orig / "test1",
         temp_orig / "test1/script.sh",
-    ]
+    }
     assert paths == expected_paths
 
 


### PR DESCRIPTION
Modify `atomic_contents_add` to accept a filter function, for improved flexibility

The filter function is called once for each item, including the item passed to `atomic_contents_add`.