### PR TITLE
Correct read of tail in DecryptInnerTar

### DIFF
--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -183,11 +183,11 @@ class SecureTarFile:
                 self._parent = parent
                 self._pos = 0
                 self._size = tarinfo.size - IV_SIZE
-                self._tail = b""
+                self._tail: bytes | None = None
 
             def read(self, size: int = 0) -> bytes:
                 """Read data."""
-                if self._tail:
+                if self._tail is not None:
                     # Finish reading tail
                     data = self._tail[:size]
                     self._tail = self._tail[size:]


### PR DESCRIPTION
Correct read of tail in `DecryptInnerTar`, we would read past the start of padding if read was called again after the tail was consumed