### PR TITLE
Add encryption helper

### DIFF
--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -316,7 +316,6 @@ class SecureTarFile:
             def write(self, data: bytes) -> None:
                 """Write data."""
                 self._parent.write(data)
-                return None
 
         try:
             self._open_file()

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -345,6 +345,7 @@ class SecureTarFile:
                 """Initialize."""
                 size = tarinfo.size + BLOCK_SIZE - tarinfo.size % BLOCK_SIZE
                 size += IV_SIZE + SECURETAR_HEADER_SIZE
+                self.encrypted_size = size
                 super().__init__(parent, size)
                 self._head = parent.securetar_header.to_bytes()
 

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -384,8 +384,11 @@ def test_tar_inside_tar_encrypt(
             inner_tar_path = temp_encrypted.joinpath(tar_info.name)
             with open(inner_tar_path, "wb") as file:
                 with istf.encrypt(tar_info) as encrypted:
+                    read = 0
                     while data := encrypted.read(bufsize):
+                        read += len(data)
                         file.write(data)
+                    assert read == encrypted.encrypted_size
 
             # Check the indicated size is correct
             assert (


### PR DESCRIPTION
Add encryption helper, the purpose is to simplify creating encrypted versions if unencrypted inner tar files