### PR TITLE
Sanitize read size in DecryptInnerTar.read

### DIFF
--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -284,7 +284,7 @@ class SecureTarFile:
                 # Last block: Append any remaining head, read tail and discard padding
                 if self._head:
                     data += self._head
-                data += self._parent.read(self._size - self._pos)
+                data += self._parent.read(max(self._size - self._pos, 0))
                 padding_len = data[-1]
                 data = data[:-padding_len]
                 self._tail = data[size:]


### PR DESCRIPTION
Sanitize read size in `DecryptInnerTar.read`

If reading past `DecryptInnerTar._size`, we would try to read a negative amount of bytes for the tail
Seen when writing tests for https://github.com/pvizeli/securetar/pull/81