### PR TITLE
Always create inner secure tar with write file mode

### DIFF
--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -148,7 +148,7 @@ class SecureTarFile:
         return _InnerSecureTarFile(
             self._tar,
             name=Path(name),
-            mode=self._mode,
+            mode="w",
             key=key,
             gzip=gzip,
             bufsize=self._bufsize,

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -829,7 +829,9 @@ def test_outer_tar_exclusive_mode(tmp_path: Path) -> None:
     outer_secure_tar_file = SecureTarFile(main_tar, "x", gzip=False)
 
     with outer_secure_tar_file:
-        with outer_secure_tar_file.create_inner_tar("any.tgz", key=os.urandom(16), gzip=True):
+        with outer_secure_tar_file.create_inner_tar(
+            "any.tgz", key=os.urandom(16), gzip=True
+        ):
             pass
 
     assert main_tar.exists()


### PR DESCRIPTION
The inner secure tar is always a stream. Creating a inner tar stream only really make sense in regular write mode. Hence hard-code the mode.

This allows to use other modes for the outer tar file, like the exclusive mode.