### PR TITLE
Wrap errors in atomic_contents_add

### DIFF
--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -11,7 +11,7 @@ import tarfile
 import time
 from contextlib import contextmanager
 from pathlib import Path, PurePath
-from typing import IO, BinaryIO
+from typing import Any, IO, BinaryIO
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import padding
@@ -87,6 +87,15 @@ class SecureTarHeader:
 
 class SecureTarError(Exception):
     """SecureTar error."""
+
+
+class AddFileError(SecureTarError):
+    """Raised when a file could not be added to an archive."""
+
+    def __init__(self, path: Path, *args: Any) -> None:
+        """Initialize."""
+        self.path = path
+        super().__init__(*args)
 
 
 class SecureTarReadError(SecureTarError):
@@ -597,6 +606,7 @@ def _add_wrap_error(tar_file: tarfile.TarFile, file_path: Path, arcname: str) ->
     try:
         tar_file.add(file_path.as_posix(), arcname=arcname, recursive=False)
     except (OSError, tarfile.TarError) as err:
-        raise SecureTarError(
+        raise AddFileError(
+            file_path,
             f"Error adding {file_path} to tarfile: {err} ({err.__class__.__name__})"
         ) from err

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -594,7 +594,7 @@ def _atomic_contents_add(
 
     try:
         dir_iterator = origin_path.iterdir()
-    except (OSError, tarfile.TarError) as err:
+    except OSError as err:
         raise AddFileError(
             origin_path,
             f"Error iterating over {origin_path}: {err} ({err.__class__.__name__})",

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -584,29 +584,45 @@ def _atomic_contents_add(
     """Append directories and/or files to the TarFile if file_filter returns False."""
 
     # Add directory only (recursive=False) to ensure we also archive empty directories
-    _add_wrap_error(tar_file, origin_path, arcname)
-
-    for directory_item in origin_path.iterdir():
-        item_arcpath = PurePath(arcname, directory_item.name)
-        if file_filter(PurePath(item_arcpath)):
-            continue
-
-        item_arcname = item_arcpath.as_posix()
-        if directory_item.is_dir() and not directory_item.is_symlink():
-            _atomic_contents_add(tar_file, directory_item, file_filter, item_arcname)
-            continue
-
-        _add_wrap_error(tar_file, directory_item, item_arcname)
-
-    return None
-
-
-def _add_wrap_error(tar_file: tarfile.TarFile, file_path: Path, arcname: str) -> None:
-    """Wrap add function with error handling."""
     try:
-        tar_file.add(file_path.as_posix(), arcname=arcname, recursive=False)
+        tar_file.add(origin_path.as_posix(), arcname=arcname, recursive=False)
     except (OSError, tarfile.TarError) as err:
         raise AddFileError(
-            file_path,
-            f"Error adding {file_path} to tarfile: {err} ({err.__class__.__name__})",
+            origin_path,
+            f"Error adding {origin_path} to tarfile: {err} ({err.__class__.__name__})",
         ) from err
+
+    try:
+        dir_iterator = origin_path.iterdir()
+    except (OSError, tarfile.TarError) as err:
+        raise AddFileError(
+            origin_path,
+            f"Error iterating over {origin_path}: {err} ({err.__class__.__name__})",
+        ) from err
+
+    for directory_item in dir_iterator:
+        try:
+            item_arcpath = PurePath(arcname, directory_item.name)
+            if file_filter(PurePath(item_arcpath)):
+                continue
+
+            item_arcname = item_arcpath.as_posix()
+            if directory_item.is_dir() and not directory_item.is_symlink():
+                _atomic_contents_add(
+                    tar_file, directory_item, file_filter, item_arcname
+                )
+                continue
+
+            tar_file.add(
+                directory_item.as_posix(), arcname=item_arcname, recursive=False
+            )
+        except (OSError, tarfile.TarError) as err:
+            raise AddFileError(
+                directory_item,
+                (
+                    f"Error adding {directory_item} to tarfile: "
+                    f"{err} ({err.__class__.__name__})"
+                ),
+            ) from err
+
+    return None

--- a/securetar/__init__.py
+++ b/securetar/__init__.py
@@ -608,5 +608,5 @@ def _add_wrap_error(tar_file: tarfile.TarFile, file_path: Path, arcname: str) ->
     except (OSError, tarfile.TarError) as err:
         raise AddFileError(
             file_path,
-            f"Error adding {file_path} to tarfile: {err} ({err.__class__.__name__})"
+            f"Error adding {file_path} to tarfile: {err} ({err.__class__.__name__})",
         ) from err

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -3,7 +3,6 @@
 import gzip
 import io
 import os
-import re
 import shutil
 import tarfile
 import time
@@ -127,27 +126,27 @@ def test_create_pure_tar(tmp_path: Path, bufsize: int) -> None:
         (
             tarfile.TarFile,
             "addfile",
-            "Error adding {temp_orig} to tarfile: Boom! \(OSError\)",
+            r"Error adding {temp_orig} to tarfile: Boom! \(OSError\)",
         ),
         (
             tarfile,
             "copyfileobj",
-            "Error adding {temp_orig}/.+ to tarfile: Boom! \(OSError\)",
+            r"Error adding {temp_orig}/.+ to tarfile: Boom! \(OSError\)",
         ),
         (
             Path,
             "is_dir",
-            "Error adding {temp_orig}/.+ to tarfile: Boom! \(OSError\)",
+            r"Error adding {temp_orig}/.+ to tarfile: Boom! \(OSError\)",
         ),
         (
             Path,
             "is_symlink",
-            "Error adding {temp_orig}/.+ to tarfile: Boom! \(OSError\)",
+            r"Error adding {temp_orig}/.+ to tarfile: Boom! \(OSError\)",
         ),
         (
             Path,
             "iterdir",
-            "Error iterating over {temp_orig}: Boom! \(OSError\)",
+            r"Error iterating over {temp_orig}: Boom! \(OSError\)",
         ),
     ],
 )

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -127,31 +127,31 @@ def test_create_pure_tar(tmp_path: Path, bufsize: int) -> None:
         (
             tarfile.TarFile,
             "addfile",
-            "Error adding {temp_orig} to tarfile: Boom! (OSError)",
+            "Error adding {temp_orig} to tarfile: Boom! \(OSError\)",
         ),
         (
             tarfile,
             "copyfileobj",
-            "Error adding {temp_orig}/README.md to tarfile: Boom! (OSError)",
+            "Error adding {temp_orig}/.+ to tarfile: Boom! \(OSError\)",
         ),
         (
             Path,
             "is_dir",
-            "Error adding {temp_orig}/README.md to tarfile: Boom! (OSError)",
+            "Error adding {temp_orig}/.+ to tarfile: Boom! \(OSError\)",
         ),
         (
             Path,
             "is_symlink",
-            "Error adding {temp_orig}/test_symlink to tarfile: Boom! (OSError)",
+            "Error adding {temp_orig}/.+ to tarfile: Boom! \(OSError\)",
         ),
         (
             Path,
             "iterdir",
-            "Error iterating over {temp_orig}: Boom! (OSError)",
+            "Error iterating over {temp_orig}: Boom! \(OSError\)",
         ),
     ],
 )
-def test_create_with_error_add_dir(
+def test_create_with_error(
     tmp_path: Path, target: Any, attribute: str, expected_error: str
 ) -> None:
     """Test error in atomic_contents_add."""
@@ -166,7 +166,7 @@ def test_create_with_error_add_dir(
         patch.object(target, attribute, side_effect=OSError("Boom!")),
         pytest.raises(
             AddFileError,
-            match=re.escape(expected_error.format(temp_orig=temp_orig)),
+            match=expected_error.format(temp_orig=temp_orig),
         ),
         SecureTarFile(temp_tar, "w") as tar_file,
     ):

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -130,14 +130,24 @@ def test_create_pure_tar(tmp_path: Path, bufsize: int) -> None:
             "Error adding {temp_orig} to tarfile: Boom! (OSError)",
         ),
         (
-            Path,
-            "iterdir",
-            "Error iterating over {temp_orig}: Boom! (OSError)",
-        ),
-        (
             tarfile,
             "copyfileobj",
             "Error adding {temp_orig}/README.md to tarfile: Boom! (OSError)",
+        ),
+        (
+            Path,
+            "is_dir",
+            "Error adding {temp_orig}/README.md to tarfile: Boom! (OSError)",
+        ),
+        (
+            Path,
+            "is_symlink",
+            "Error adding {temp_orig}/test_symlink to tarfile: Boom! (OSError)",
+        ),
+        (
+            Path,
+            "iterdir",
+            "Error iterating over {temp_orig}: Boom! (OSError)",
         ),
     ],
 )

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from securetar import (
+    AddFileError,
     SECURETAR_MAGIC,
     SecureTarError,
     SecureTarFile,
@@ -130,7 +131,7 @@ def test_create_with_error(tmp_path: Path) -> None:
     with (
         patch.object(tarfile.TarFile, "addfile", side_effect=OSError("Boom!")),
         pytest.raises(
-            SecureTarError,
+            AddFileError,
             match=re.escape(f"Error adding {temp_orig} to tarfile: Boom! (OSError)"),
         ),
         SecureTarFile(temp_tar, "w") as tar_file,


### PR DESCRIPTION
Wrap errors in `atomic_contents_add` to include the filename of the file which could not be added to aid debugging